### PR TITLE
Remove AI_ADDRCONFIG flag from getAddrInfo hints

### DIFF
--- a/lib/Network/Http/Connection.hs
+++ b/lib/Network/Http/Connection.hs
@@ -189,7 +189,7 @@ openConnection h1' p = do
     }
   where
     hints = defaultHints {
-        addrFlags = [AI_ADDRCONFIG, AI_NUMERICSERV],
+        addrFlags = [AI_NUMERICSERV],
         addrSocketType = Stream
     }
     h2' = if p == 80


### PR DESCRIPTION
Do not use AI_ADDRCONFIG flag in getAddrInfo hints as it cannot handle '127.0.0.1' on IPv6-only machines.